### PR TITLE
fix: issues in contao 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /composer.lock
 /vendor/
 /.php_cs.cache

--- a/src/Action/SyncAction.php
+++ b/src/Action/SyncAction.php
@@ -20,7 +20,7 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 
-#[Route('/contao/youtubesync', name: SyncAction::class, defaults: ['_scope' => 'backend', "_token_check" => false])]
+#[Route('/contao/youtubesync', name: self::class, defaults: ['_scope' => 'backend', '_token_check' => false])]
 class SyncAction
 {
     private $newsYouTubeSync;

--- a/src/Action/SyncAction.php
+++ b/src/Action/SyncAction.php
@@ -20,12 +20,7 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 
-/**
- * @Route("/contao/youtubesync",
- *   name=SyncAction::class,
- *   defaults={"_scope": "backend", "_token_check": false}
- * )
- */
+#[Route('/contao/youtubesync', name: SyncAction::class, defaults: ['_scope' => 'backend', "_token_check" => false])]
 class SyncAction
 {
     private $newsYouTubeSync;

--- a/src/Command/SyncCommand.php
+++ b/src/Command/SyncCommand.php
@@ -32,7 +32,7 @@ class SyncCommand extends Command
         $this->setDescription('Synchronises all configured news archives with YouTube.');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         ($this->newsYouTubeSync)();
 

--- a/src/Command/SyncCommand.php
+++ b/src/Command/SyncCommand.php
@@ -36,6 +36,6 @@ class SyncCommand extends Command
     {
         ($this->newsYouTubeSync)();
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -32,10 +32,11 @@ class Plugin implements BundlePluginInterface, RoutingPluginInterface
         ];
     }
 
-    public function getRouteCollection(LoaderResolverInterface $resolver, KernelInterface $kernel)
+    public function getRouteCollection(LoaderResolverInterface $resolver, KernelInterface $kernel): ?RouteCollection
     {
         return $resolver
             ->resolve(__DIR__.'/../Resources/config/routing.yml')
-            ->load(__DIR__.'/../Resources/config/routing.yml');
+            ->load(__DIR__.'/../Resources/config/routing.yml')
+        ;
     }
 }

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -32,9 +32,10 @@ class Plugin implements BundlePluginInterface, RoutingPluginInterface
         ];
     }
 
-    public function getRouteCollection(LoaderResolverInterface $resolver, KernelInterface $kernel): ?RouteCollection
+    public function getRouteCollection(LoaderResolverInterface $resolver, KernelInterface $kernel)
     {
-        return $resolver->resolve('@ContaoYouTubeSyncBundle/src/Action')
-            ->load('@ContaoYouTubeSyncBundle/src/Action');
+        return $resolver
+            ->resolve(__DIR__.'/../Resources/config/routing.yml')
+            ->load(__DIR__.'/../Resources/config/routing.yml');
     }
 }

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -19,6 +19,7 @@ use Contao\ManagerPlugin\Routing\RoutingPluginInterface;
 use Contao\NewsBundle\ContaoNewsBundle;
 use InspiredMinds\ContaoYouTubeSync\ContaoYouTubeSyncBundle;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Routing\RouteCollection;
 
@@ -35,8 +36,8 @@ class Plugin implements BundlePluginInterface, RoutingPluginInterface
     public function getRouteCollection(LoaderResolverInterface $resolver, KernelInterface $kernel): ?RouteCollection
     {
         return $resolver
-            ->resolve(__DIR__.'/../Resources/config/routing.yml')
-            ->load(__DIR__.'/../Resources/config/routing.yml')
+            ->resolve(__DIR__.'/../Action', Kernel::MAJOR_VERSION >= 6 ? 'attribute' : 'annotation')
+            ->load(__DIR__.'/../Action')
         ;
     }
 }

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -34,9 +34,7 @@ class Plugin implements BundlePluginInterface, RoutingPluginInterface
 
     public function getRouteCollection(LoaderResolverInterface $resolver, KernelInterface $kernel): ?RouteCollection
     {
-        return $resolver
-            ->resolve(__DIR__.'/../Resources/config/routing.yml')
-            ->load(__DIR__.'/../Resources/config/routing.yml')
-        ;
+        return $resolver->resolve('@ContaoYouTubeSyncBundle/src/Action')
+            ->load('@ContaoYouTubeSyncBundle/src/Action');
     }
 }

--- a/src/ContaoYouTubeSyncBundle.php
+++ b/src/ContaoYouTubeSyncBundle.php
@@ -26,9 +26,4 @@ class ContaoYouTubeSyncBundle extends Bundle
 
         return $this->extension;
     }
-
-    public function getPath(): string
-    {
-        return \dirname(__DIR__);
-    }
 }

--- a/src/ContaoYouTubeSyncBundle.php
+++ b/src/ContaoYouTubeSyncBundle.php
@@ -26,4 +26,9 @@ class ContaoYouTubeSyncBundle extends Bundle
 
         return $this->extension;
     }
+
+    public function getPath(): string
+    {
+        return \dirname(__DIR__);
+    }
 }

--- a/src/Resources/config/routing.yml
+++ b/src/Resources/config/routing.yml
@@ -1,3 +1,0 @@
-contao_youtube_sync:
-  resource: "@ContaoYouTubeSyncBundle/Action"
-  type: attribute

--- a/src/Resources/config/routing.yml
+++ b/src/Resources/config/routing.yml
@@ -1,3 +1,0 @@
-contao_youtube_sync:
-  resource: "@ContaoYouTubeSyncBundle/Action"
-  type: annotation

--- a/src/Resources/config/routing.yml
+++ b/src/Resources/config/routing.yml
@@ -1,3 +1,3 @@
 contao_youtube_sync:
-  resource: "../../Action"
+  resource: "@ContaoYouTubeSyncBundle/Action"
   type: attribute

--- a/src/Resources/config/routing.yml
+++ b/src/Resources/config/routing.yml
@@ -1,0 +1,3 @@
+contao_youtube_sync:
+  resource: "../../Action"
+  type: attribute


### PR DESCRIPTION
Hello folks,

after upgrading from contao 4.13 to 5.6 I get 2 errors:

```
PHP Fatal error:  Declaration of InspiredMinds\ContaoYouTubeSync\Command\SyncCommand::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int in /var/www/html/vendor/inspiredminds/contao-youtube-sync/src/Command/SyncCommand.php on line 35
```

and

```
In ContaoSetupCommand.php line 143:
                                                                                                                                                                                                                                             
  An error occurred while executing the "/usr/bin/php8.3 -dmemory_limit=-1 /var/www/html/vendor/contao/manager-bundle/bin/contao-console cache:warmup --env=prod --ansi" command: 15:39:09 CRITICAL  [console] Error th  
  rown while running command "cache:warmup --env=prod --ansi". Message: "Cannot load resource "@ContaoYouTubeSyncBundle/Action". Make sure the "ContaoYouTubeSyncBundle" bundle is correctly registered and loaded in the application kerne  
  l class. If the bundle is registered, make sure the bundle path "@ContaoYouTubeSyncBundle/Action" is not empty." ["exception" => Symfony\Component\Config\Exception\Loader  
  LoadException^ { …},"command" => "cache:warmup --env=prod --ansi
  208m","message" => "Cannot load resource "@ContaoYouTubeSyncBundle/Action". Make sure the "ContaoYouTubeSyncBundle" bundle is correctly registered and loaded in the application ker  
  nel class. If the bundle is registered, make sure the bundle path "@ContaoYouTubeSyncBundle/Action" is not empty."]                                                                                        
                                                                                                                                                                                                                                             
  In Loader.php line 68:                                                                                                                                                                                                           
                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                 
    Cannot load resource "@ContaoYouTubeSyncBundle/Action". Make sure the "ContaoYouTubeSyncBundle" bundle is correctly registered and loaded in the application kernel class. If the bundle is registered, make sure the bundle pa  
  th "@Conta                                                                                                                                                                                                                         
    oYouTubeSyncBundle/Action" is not empty.                                                                                                                                                                                         
                                                                                                                                                                    
  cache:warmup [--no-optional-warmers]                                                                                                                                                                                             
                                                                                                                                                                                                                                             

contao:setup

Script @php vendor/bin/contao-setup handling the post-install-cmd event returned with error code 1
```

This pr fixes that. Tested in contao 4.13 and 5.6.

Bye Defcon0